### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ chrono = { version = "0.4", features = ["serde"] }
 flexi_logger = "0.10"
 serde_derive = "1.0"
 bigdecimal = {version = "0.0", features = ["serde"]}
-version-sync = "0.7"
+version-sync = "0.8"


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.