### PR TITLE
A few small cleanups

### DIFF
--- a/src/de/conversion_error.rs
+++ b/src/de/conversion_error.rs
@@ -4,25 +4,25 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ConversionError {
-    /// The DbValue cannot be converted into the desired rust type.
+    /// The `DbValue` cannot be converted into the desired rust type.
     #[error(
         "The DbValue cannot be converted into the desired rust type: value types do not match"
     )]
     ValueType(String),
 
-    /// The DbValue is to big or too small (negative) for conversion into the desired rust type.
+    /// The `DbValue` is to big or too small (negative) for conversion into the desired rust type.
     #[error(
         "The DbValue is too big or too small for the desired rust type: number range exceeded"
     )]
     NumberRange(String),
 
-    /// The DbValue was not yet completely loaded, and further loading is not possible anymore.
+    /// The `DbValue` was not yet completely loaded, and further loading is not possible anymore.
     #[error(
         "The DbValue was not yet completely loaded, and further loading is not possible anymore"
     )]
     Incomplete(String),
 
-    /// A custom error that describes another reason for a conversion failure
+    /// A custom error that describes another reason for a conversion failure.
     #[error("Conversion fails due to given root cause")]
     Other(Box<dyn std::error::Error + Send + Sync>),
 }

--- a/src/de/db_value.rs
+++ b/src/de/db_value.rs
@@ -1,7 +1,6 @@
 use crate::de::field_deserializer::FieldDeserializer;
 use crate::de::{DbValueInto, DeserializationError};
 use std::marker::Sized;
-use std::{i16, i32, i8, u16, u32, u8};
 
 /// Provides the conversion of a database value into a standard rust type.
 pub trait DbValue:

--- a/src/de/deserializable_resultset.rs
+++ b/src/de/deserializable_resultset.rs
@@ -6,7 +6,7 @@ use std::marker::Sized;
 pub trait DeserializableResultset: Sized {
     /// Error type of the database driver.
     type E: From<DeserializationError> + Sized;
-    /// Concrete type for the DB row, which must implement `DeserializabeRow`.
+    /// Concrete type for the DB row, which must implement `DeserializableRow`.
     type ROW: DeserializableRow;
 
     /// Returns true if more than one row is contained, including eventually not yet fetched rows.

--- a/src/de/deserializable_row.rs
+++ b/src/de/deserializable_row.rs
@@ -11,7 +11,7 @@ pub trait DeserializableRow: Sized {
     /// The value type used by the database driver.
     type V: DbValue;
 
-    /// Returns the current length of the row (which is decremented with each call to next()).
+    /// Returns the current length of the row (which is decremented with each call to `.next()`).
     fn len(&self) -> usize;
 
     /// Removes and returns the next value.

--- a/src/de/row_deserializer.rs
+++ b/src/de/row_deserializer.rs
@@ -216,7 +216,7 @@ where
     }
 
     #[inline]
-    fn deserialize_seq<V>(mut self, visitor: V) -> DeserializationResult<V::Value>
+    fn deserialize_seq<V>(self, visitor: V) -> DeserializationResult<V::Value>
     where
         V: serde::de::Visitor<'x>,
     {
@@ -286,7 +286,7 @@ where
     }
 
     fn deserialize_struct<V>(
-        mut self,
+        self,
         _name: &'static str,
         _fields: &'static [&'static str],
         visitor: V,
@@ -322,7 +322,7 @@ where
         visitor.visit_bytes(&DbValueInto::<Vec<u8>>::try_into(self.next_value()?)?)
     }
 
-    fn deserialize_tuple<V>(mut self, _len: usize, visitor: V) -> DeserializationResult<V::Value>
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> DeserializationResult<V::Value>
     where
         V: serde::de::Visitor<'x>,
     {

--- a/src/de/rs_deserializer.rs
+++ b/src/de/rs_deserializer.rs
@@ -234,7 +234,7 @@ where
         rd.deserialize_option(visitor)
     }
 
-    fn deserialize_seq<V>(mut self, visitor: V) -> DeserializationResult<V::Value>
+    fn deserialize_seq<V>(self, visitor: V) -> DeserializationResult<V::Value>
     where
         V: serde::de::Visitor<'x>,
     {


### PR DESCRIPTION
This PR aims to resolve a couple of issues reported by `cargo clippy`:

<details>
<summary>Clippy outputs</summary>

```plain
$ cargo clippy

    Checking serde_db v0.11.1 (<SNIP>/rust-serde_db)
warning: variable does not need to be mutable
   --> src/de/row_deserializer.rs:219:27
    |
219 |     fn deserialize_seq<V>(mut self, visitor: V) -> DeserializationResult<V::Value>
    |                           ----^^^^
    |                           |
    |                           help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: variable does not need to be mutable
   --> src/de/row_deserializer.rs:289:9
    |
289 |         mut self,
    |         ----^^^^
    |         |
    |         help: remove this `mut`

warning: variable does not need to be mutable
   --> src/de/row_deserializer.rs:325:29
    |
325 |     fn deserialize_tuple<V>(mut self, _len: usize, visitor: V) -> DeserializationResult<V::Value>
    |                             ----^^^^
    |                             |
    |                             help: remove this `mut`

warning: variable does not need to be mutable
   --> src/de/rs_deserializer.rs:237:27
    |
237 |     fn deserialize_seq<V>(mut self, visitor: V) -> DeserializationResult<V::Value>
    |                           ----^^^^
    |                           |
    |                           help: remove this `mut`

error: item in documentation is missing backticks
  --> src/de/conversion_error.rs:7:13
   |
7  |     /// The DbValue cannot be converted into the desired rust type.
   |             ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
note: the lint level is defined here
  --> src/lib.rs:14:9
   |
14 | #![deny(clippy::pedantic)]
   |         ^^^^^^^^^^^^^^^^
   = note: `#[deny(clippy::doc_markdown)]` implied by `#[deny(clippy::pedantic)]`
help: try
   |
7  |     /// The `DbValue` cannot be converted into the desired rust type.
   |             ~~~~~~~~~

error: item in documentation is missing backticks
  --> src/de/conversion_error.rs:13:13
   |
13 |     /// The DbValue is to big or too small (negative) for conversion into the desired rust type.
   |             ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
help: try
   |
13 |     /// The `DbValue` is to big or too small (negative) for conversion into the desired rust type.
   |             ~~~~~~~~~

error: item in documentation is missing backticks
  --> src/de/conversion_error.rs:19:13
   |
19 |     /// The DbValue was not yet completely loaded, and further loading is not possible anymore.
   |             ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
help: try
   |
19 |     /// The `DbValue` was not yet completely loaded, and further loading is not possible anymore.
   |             ~~~~~~~~~

error: importing legacy numeric constants
  --> src/de/db_value.rs:4:11
   |
4  | use std::{i16, i32, i8, u16, u32, u8};
   |           ^^^
   |
   = help: remove this import
   = note: then `i16::<CONST>` will resolve to the respective associated constant
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
note: the lint level is defined here
  --> src/lib.rs:13:9
   |
13 | #![deny(clippy::all)]
   |         ^^^^^^^^^^^
   = note: `#[deny(clippy::legacy_numeric_constants)]` implied by `#[deny(clippy::all)]`

error: importing legacy numeric constants
 --> src/de/db_value.rs:4:16
  |
4 | use std::{i16, i32, i8, u16, u32, u8};
  |                ^^^
  |
  = help: remove this import
  = note: then `i32::<CONST>` will resolve to the respective associated constant
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants

error: importing legacy numeric constants
 --> src/de/db_value.rs:4:21
  |
4 | use std::{i16, i32, i8, u16, u32, u8};
  |                     ^^
  |
  = help: remove this import
  = note: then `i8::<CONST>` will resolve to the respective associated constant
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants

error: importing legacy numeric constants
 --> src/de/db_value.rs:4:25
  |
4 | use std::{i16, i32, i8, u16, u32, u8};
  |                         ^^^
  |
  = help: remove this import
  = note: then `u16::<CONST>` will resolve to the respective associated constant
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants

error: importing legacy numeric constants
 --> src/de/db_value.rs:4:30
  |
4 | use std::{i16, i32, i8, u16, u32, u8};
  |                              ^^^
  |
  = help: remove this import
  = note: then `u32::<CONST>` will resolve to the respective associated constant
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants

error: importing legacy numeric constants
 --> src/de/db_value.rs:4:35
  |
4 | use std::{i16, i32, i8, u16, u32, u8};
  |                                   ^^
  |
  = help: remove this import
  = note: then `u8::<CONST>` will resolve to the respective associated constant
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants

error: item in documentation is missing backticks
  --> src/de/deserializable_row.rs:14:87
   |
14 |     /// Returns the current length of the row (which is decremented with each call to next()).
   |                                                                                       ^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
help: try
   |
14 |     /// Returns the current length of the row (which is decremented with each call to `next()`).
   |                                                                                       ~~~~~~~~

warning: `serde_db` (lib) generated 4 warnings
error: could not compile `serde_db` (lib) due to 10 previous errors; 4 warnings emitted
```

</details>